### PR TITLE
Update URLs and references now repo has been renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This dashboard is a Sinatra app, hosted on Heroku, and intended to be used by GO
 
 ## Using the dashboard
 
-Bookmark `https://govuk-zendesk-display-screen.herokuapp.com/`. It will automatically redirect to the latest iteration of the dashboard. Try to avoid bookmarking the `/frame-splits` URL itself, as then you won't benefit from future changes.
+Bookmark `https://govuk-2ndline-dashboard.herokuapp.com/`. It will automatically redirect to the latest iteration of the dashboard. Try to avoid bookmarking the `/frame-splits` URL itself, as then you won't benefit from future changes.
 
 ## Running the app locally
 
-Replace the following variables with values [retrieved from Heroku](https://dashboard.heroku.com/apps/govuk-zendesk-display-screen/settings).
+Replace the following variables with values [retrieved from Heroku](https://dashboard.heroku.com/apps/govuk-2ndline-dashboard/settings).
 
 ```
 ZENDESK_SUBDOMAIN='govuk' \

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
-  "name": "GOV.UK Zendesk Display Screen",
-  "description": "Display screen for GOV.UK Zendesk ticket statistics",
-  "repository": "https://github.com/alphagov/govuk-zendesk-display-screen",
+  "name": "GOV.UK Technical 2nd Line dashboard",
+  "description": "Dashboard screen for GOV.UK Technical 2nd Line team",
+  "repository": "https://github.com/alphagov/govuk-technical-2ndline-dashboard",
   "env": {
     "ZENDESK_SUBDOMAIN": {
       "required": true

--- a/views/summary.erb
+++ b/views/summary.erb
@@ -23,7 +23,7 @@
       <div class="row">
         <h2>About this dashboard</h2>
         <p>
-            You need to provide auth credentials to see the <strong>Zendesk frame</strong> (top right). <a href="https://dashboard.heroku.com/apps/govuk-zendesk-display-screen/settings" target="_top">Retrieve the credentials from Heroku</a>.
+            You need to provide auth credentials to see the <strong>Zendesk frame</strong> (top right). <a href="https://dashboard.heroku.com/apps/govuk-2ndline-dashboard/settings" target="_top">Retrieve the credentials from Heroku</a>.
         </p>
         <p>
             You need to be on the VPN to see the <strong>Icinga frame</strong> (bottom right). Note that there are currently a lot of ignorable alerts - the only ones you will want to pay attention to are:


### PR DESCRIPTION
This repo used to be called govuk-zendesk-display-screen but was renamed to reflect its broader scope. The corresponding Heroku project no longer worked, so a new one was created, which is now referenced in this commit. The old one will be deleted once this commit is merged.