### PR TITLE
Remove password protection from Zendesk panel

### DIFF
--- a/displayscreen.rb
+++ b/displayscreen.rb
@@ -14,13 +14,6 @@ configure do
 end
 
 helpers do
-  def user_protected!
-    return if user_authorized?
-
-    headers["WWW-Authenticate"] = 'Basic realm="GOV.UK Zendesk Display Screen"'
-    halt 401
-  end
-
   def user_authorized?
     @auth ||= Rack::Auth::Basic::Request.new(request.env)
     @auth.provided? && @auth.basic? && @auth.credentials && @auth.credentials == [ENV["AUTH_USERNAME"], ENV["AUTH_PASSWORD"]]
@@ -60,7 +53,6 @@ get "/blinken" do
 end
 
 get "/zendesk" do
-  user_protected!
   dark_mode = true unless params[:dark_mode] && params[:dark_mode] == "false"
   hide_low_queue = true unless params[:hide_low_queue] && params[:hide_low_queue] == "false"
   number_of_tickets = { "high" => 0, "normal" => 0, "low" => 0 }

--- a/views/summary.erb
+++ b/views/summary.erb
@@ -23,9 +23,6 @@
       <div class="row">
         <h2>About this dashboard</h2>
         <p>
-            You need to provide auth credentials to see the <strong>Zendesk frame</strong> (top right). <a href="https://dashboard.heroku.com/apps/govuk-2ndline-dashboard/settings" target="_top">Retrieve the credentials from Heroku</a>.
-        </p>
-        <p>
             You need to be on the VPN to see the <strong>Icinga frame</strong> (bottom right). Note that there are currently a lot of ignorable alerts - the only ones you will want to pay attention to are:
         </p>
         <ul>


### PR DESCRIPTION
The Zendesk panel on the 2nd line dashboard required a username and password to be supplied: https://govuk-2ndline-dashboard.herokuapp.com/

The Zendesk ticket count is not particularly sensitive information, and it's a pain to have to dig out the credentials every time, which might put some 2nd liners off using the dashboard.