### PR TITLE
Update link to Sidekiq Grafana dashboard

### DIFF
--- a/views/summary.erb
+++ b/views/summary.erb
@@ -39,7 +39,7 @@
             <li>See the <a href="https://docs.publishing.service.gov.uk/kubernetes/cheatsheet.html" target="_top">EKS/Kubernetes infrastructure</a> page in the Developer Docs.</li>
             <li>See the <a href="https://govuk-kubernetes-cluster-user-docs.publishing.service.gov.uk/" target="_top">GOV.UK Kubernetes platform user documentation</a>. This will eventually be absorbed into the Developer Docs.</li>
             <li>Dashboards are on <a href="https://grafana.eks.production.govuk.digital/" target="_top">https://grafana.eks.production.govuk.digital/</a> and no longer require VPN. Don’t get confused by the <a href="https://grafana.production.govuk.digital" target="_top">old Grafana</a>.</li>
-            <li>See Sidekiq queue lengths and age-of-oldest-job on the <a href="https://grafana.eks.production.govuk.digital/d/2Yy8PzmVk" target="_top">Sidekiq Grafana dashboard</a>. The <a href="https://sidekiq-monitoring.integration.govuk.digital/publishing-api/queues" target="_top">old detailed Sidekiq dashboard</a> is not yet available for EKS.</li>
+            <li>See Sidekiq queue lengths and age-of-oldest-job on the <a href="https://grafana.eks.production.govuk.digital/d/sidekiq-queues/sidekiq3a-queue-length-max-delay" target="_top">Sidekiq Grafana dashboard</a>. The <a href="https://sidekiq-monitoring.integration.govuk.digital/publishing-api/queues" target="_top">old detailed Sidekiq dashboard</a> is not yet available for EKS.</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## What
This PR updates the link to the Sidekiq Grafana dashboard on the landing page.

## Why
The previous link was broken.

## Visual changes
None.