### PR TITLE
Remove reference to crawler/mirror Icinga alerts

### DIFF
--- a/views/summary.erb
+++ b/views/summary.erb
@@ -28,7 +28,6 @@
         <ul>
             <li>“scheduled publications in Whitehall not queued” / “overdue publications in Whitehall”
             <li>“Travel Advice email alert check” / “Medical Safety Email alert check”</li>
-            <li>Anything to do with crawler/mirrors</li>
             <li>Anything to do with Licensify</li>
         </ul>
       </div>


### PR DESCRIPTION
The job has now moved to https://github.com/alphagov/govuk-mirror, and associated alerts have been created in Prometheus in https://github.com/alphagov/govuk-helm-charts/pull/1359.