### PR TITLE
Remove reference to scheduled Whitehall publications

### DIFF
--- a/views/blinken.erb
+++ b/views/blinken.erb
@@ -15,7 +15,6 @@
         You need to be on the VPN to see the Icinga alerts below. You can ignore most alerts - the only ones that still need attention are:
       </p>
       <ul>
-          <li>“overdue publications in Whitehall”</li>
           <li>“Travel Advice email alert check” / “Medical Safety Email alert check”</li>
           <li>Anything to do with Licensify</li>
       </ul>

--- a/views/blinken.erb
+++ b/views/blinken.erb
@@ -15,7 +15,7 @@
         You need to be on the VPN to see the Icinga alerts below. You can ignore most alerts - the only ones that still need attention are:
       </p>
       <ul>
-          <li>“scheduled publications in Whitehall not queued” / “overdue publications in Whitehall”
+          <li>“overdue publications in Whitehall”</li>
           <li>“Travel Advice email alert check” / “Medical Safety Email alert check”</li>
           <li>Anything to do with Licensify</li>
       </ul>


### PR DESCRIPTION
This was ported to the new platform in https://github.com/alphagov/govuk-helm-charts/pull/1677