### PR TITLE
Add missing `name` property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on: [push, pull_request]
 jobs:
   snyk-security:


### PR DESCRIPTION
This should include `name: CI` as per our [documented convention](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#name-of-ci-workflow-and-jobs).